### PR TITLE
Fixed carla_spawn_objects typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In Terminal 2:
 ```
 # run in carla-cyber container
 cd /apollo/cyber/carla_bridge
-python carla_spawn_object/carla_spawn_object.py
+python carla_spawn_objects/carla_spawn_objects.py
 ```
 
 ### Run Apollo Dreamview & modules


### PR DESCRIPTION
The problem with the `spawn_objects` script as described in #1 is that the tutorial has a typo.

https://github.com/casper-auto/carla-apollo/blob/5bc66a8fb7624673ad10f850837bc9fb390cb996/README.md?plain=1#L72
Should be `spawn_objects`, not `spawn_object` (with an 's')!

---

this probably resovles #1